### PR TITLE
Removes function return type

### DIFF
--- a/legendary/models/game.py
+++ b/legendary/models/game.py
@@ -86,7 +86,7 @@ class Game:
         return self.metadata and 'mainGameItem' in self.metadata
 
     @property
-    def is_origin_game(self) -> bool:
+    def is_origin_game(self):
         return self.third_party_store and self.third_party_store.lower() in ['origin', 'the ea app']
 
     @property


### PR DESCRIPTION
Fixes case where an empty literal is returned. An empty literal cannot be assigned to a return type bool